### PR TITLE
Add Participation Streak Tracking to Weekly Insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ ZenGrid is a decentralized application for tracking mental health and emotional 
 - Complete data ownership and privacy
 - Weekly insights with trend analysis
 - Entry statistics and progress tracking
+- Continuous participation streak tracking
 
 ## Contract Functions
 
@@ -20,14 +21,16 @@ ZenGrid is a decentralized application for tracking mental health and emotional 
 - View aggregated statistics
 - Generate weekly insights
 - Track emotional trends
+- Monitor participation streaks
 
 ## Weekly Insights
 
-The new weekly insights feature provides:
+The weekly insights feature provides:
 - Average emotional score for the week
 - Trend analysis (improving/declining/stable)
 - Entry completion tracking
 - Week-over-week comparisons
+- Continuous participation streak count
 
 ## Getting Started
 
@@ -35,3 +38,4 @@ The new weekly insights feature provides:
 2. Connect your wallet to ZenGrid
 3. Start tracking your emotional wellbeing
 4. Generate weekly insights to track your progress
+5. Build your participation streak by recording entries consistently

--- a/contracts/zen_grid.clar
+++ b/contracts/zen_grid.clar
@@ -19,7 +19,8 @@
     { 
       avg-score: uint,
       trend: (string-utf8 20),
-      entry-count: uint
+      entry-count: uint,
+      streak: uint
     }
 )
 
@@ -43,6 +44,14 @@
             "declining"
             "stable"
         )
+    )
+)
+
+(define-private (calculate-streak (user principal) (current-week uint))
+    (let ((prev-insight (map-get? weekly-insights { user: user, week: (- current-week u1) })))
+        (if (is-some prev-insight)
+            (+ (get streak (unwrap-panic prev-insight)) u1)
+            u1)
     )
 )
 
@@ -96,6 +105,7 @@
                         u0))
             (prev-insight (map-get? weekly-insights { user: tx-sender, week: (- current-week u1) }))
             (prev-avg (default-to u0 (get avg-score prev-insight)))
+            (streak (calculate-streak tx-sender current-week))
         )
         (if (> (get count entries) u0)
             (ok (map-set weekly-insights
@@ -103,7 +113,8 @@
                 {
                     avg-score: avg-score,
                     trend: (calculate-trend avg-score prev-avg),
-                    entry-count: (get count entries)
+                    entry-count: (get count entries),
+                    streak: streak
                 }))
             ERR-NO-ENTRIES)
     )


### PR DESCRIPTION
This PR enhances the weekly insights feature by adding participation streak tracking. This addition helps encourage consistent engagement with mental health tracking by showing users how many consecutive weeks they have been actively participating.

Changes made:
- Added a `streak` field to the weekly insights data structure
- Implemented `calculate-streak` private function to track consecutive weeks of participation
- Updated the `generate-weekly-insight` function to include streak calculation
- Added new test cases to verify streak tracking functionality
- Updated documentation to reflect new feature

The streak counter increases when users generate weekly insights in consecutive weeks, providing a gamification element that encourages regular participation in mental health tracking.

No breaking changes were introduced, and all existing functionality remains intact.